### PR TITLE
docs: Sprint-1-Planung (Auftrag 4.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 coverage/
 .vite/
 *.tsbuildinfo
+.serena/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Live-Crime-Investigation/
 - **Sprints:** 2 Wochen, insgesamt 4 Sprints à 2 Wochen + 1 Woche Puffer/Präsentation (9 Wochen total).
 - **Ritual:** Daily Standup (kurz), Sprint Planning zu Sprintbeginn, Sprint Review + Retro zu Sprintende.
 - **Backlog-Werkzeug:** GitHub Issues + Projects Board (Spalten: `Backlog`, `Sprint Backlog`, `In Progress`, `Review`, `Done`).
-- **Definition of Done:** Code gemerged in `main`, CI grün (Lint+Typecheck+Test), manuell mit 2+ Browser-Tabs durchgespielt, README/CLAUDE.md aktualisiert falls Architektur betroffen.
+- **Definition of Done:** sechs Kriterien, verbindlich ab Sprint 1 — siehe [docs/definition-of-done.md](docs/definition-of-done.md).
+- **Portfolio (Pflichtnachweis):** [docs/portfolio.md](docs/portfolio.md) — Team, Vision, Backlog, Sprint-Blöcke.
+- **Sprint 1 (aktuell):** Ziel, Schätzung und Sprint Backlog in [docs/sprint-1-planning.md](docs/sprint-1-planning.md), Refinement-Protokoll in [docs/refinement-sprint-1.md](docs/refinement-sprint-1.md).
 
 ### Sprint-Plan (Vorschlag)
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@case-zero/shared": "*",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -101,7 +101,7 @@ io.on("connection", (socket) => {
     if (!room) return;
     room.state.started = true;
     io.to(code).emit("room:state", room.state);
-    scheduleTimeline(code, room);
+    scheduleTimeline(room);
   });
 
   socket.on("board:addNode", ({ code, node }) => {
@@ -143,7 +143,7 @@ io.on("connection", (socket) => {
   });
 });
 
-function scheduleTimeline(code: string, room: Room) {
+function scheduleTimeline(room: Room) {
   for (const event of room.caseDef.timeline) {
     setTimeout(() => {
       const targets = room.state.players.filter((p) =>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/docs/definition-of-done.md
+++ b/docs/definition-of-done.md
@@ -1,0 +1,30 @@
+# Definition of Done — CASE//ZERO
+
+Modul 426 · AP 25b · gültig ab Sprint 1 (08.09.2026) · beschlossen an Modultag 4
+
+Die **Definition of Done gilt für jede Story**. Die **Akzeptanzkriterien gelten für genau eine**
+Story und stehen im jeweiligen Issue. Eine Story ist erst dann `Done`, wenn *alle* sechs Punkte
+unten erfüllt sind — nicht "fast", nicht "läuft bei mir".
+
+| # | Kriterium | Woran wir es prüfen |
+|---|---|---|
+| 1 | Alle Akzeptanzkriterien der Story sind erfüllt | Checkboxen im Issue sind abgehakt |
+| 2 | Der Code liegt im Repository auf `master` | Merge über Pull Request, kein direkter Push auf `master` |
+| 3 | Eine zweite Person hat den Code angeschaut | PR hat mindestens ein `Approved`-Review von jemand anderem |
+| 4 | Die CI ist grün | GitHub-Actions-Lauf am PR: `npm run lint`, `npm run typecheck`, `npm run test` ohne Fehler |
+| 5 | Es läuft bei allen im Team | Nach `npm install && npm run dev` hat eine zweite Person die Story lokal durchgeklickt |
+| 6 | Das Board ist aktuell | Issue steht in `Done`, Story Points und Sprint-Milestone sind gesetzt |
+
+## Warum genau diese sechs
+
+- **Punkt 3 und 5 sind neu für uns.** In Sprint 0 hat faktisch jede Person nur ihren eigenen
+  Stand gesehen. Ohne diese zwei Punkte hätten wir im Review fünf verschiedene Meinungen darüber,
+  was "fertig" heisst.
+- **Punkt 4 kostet uns nichts**, weil die CI (`.github/workflows/ci.yml`) bereits steht — sie muss
+  nur ernst genommen werden.
+- **Bewusst nicht drin:** Testabdeckung in Prozent (haben wir noch nicht sinnvoll messbar),
+  Deployment auf einen Server (erst ab Sprint 3 realistisch), vollständige Dokumentation jeder
+  Funktion (würden wir nicht durchhalten). Was wir hinschreiben, halten wir ein.
+
+An **Modultag 5** schauen wir die DoD erneut an und schärfen sie mit den Erfahrungen aus den
+ersten Stories.

--- a/docs/portfolio.md
+++ b/docs/portfolio.md
@@ -1,0 +1,181 @@
+# Portfolio — CASE//ZERO
+
+Modul 426 · Software mit agilen Methoden entwickeln · AP 25b · N. Fricker
+Repository: <https://github.com/lars11093/Live-Crime-Investigation> · Board: GitHub Issues + Projects
+
+> **Vor der Abgabe ausfüllen** (Platzhalter `_<…>_`):
+> Namen und Rollen in Abschnitt 1 · Link/Screenshot Vision Board in Abschnitt 2 ·
+> Link zum Foto der Story Map in Abschnitt 2 · Personen in den Task-Tabellen in
+> [sprint-1-planning.md](sprint-1-planning.md).
+
+---
+
+## 1. Team und Produkt
+
+### Team
+
+| Person | Scrum-Rolle | Schwerpunkt |
+|---|---|---|
+| Lars Herrmann | Entwickler | Repo, CI, Server |
+| `_<Name>_` | Product Owner (und Entwickler) | Anforderungen, Abnahme |
+| `_<Name>_` | Scrum Master (und Entwickler) | Prozess, Timeboxen, Impediments |
+| `_<Name>_` | Entwickler | |
+| `_<Name>_` | Entwickler | |
+
+Product Owner und Scrum Master sind gleichzeitig Entwickler im Team — bei fünf Personen und
+neun Wochen ist eine reine Rollentrennung nicht sinnvoll.
+
+### Produkt
+
+**CASE//ZERO** ist ein digitales Ermittlungsspiel. Ein Team untersucht gemeinsam einen einzigen,
+hochwertig ausgearbeiteten Kriminalfall: Tatort absuchen, Beweise sammeln und kombinieren,
+Verdächtige und ihre Aussagen prüfen, sichergestellte Geräte digital-forensisch auswerten und am
+Ende eine begründete Anklage abgeben. Der Look ist ein dunkles "Police-OS"-Terminal.
+
+**Abgrenzung:** Ein Fall in hoher Qualität statt zehn oberflächlicher. Echtes Netzwerk-Multiplayer,
+Sprachausgabe und eine mobile App sind bewusst ausgeschlossen (Won't).
+
+**Technisch:** React 18 + Vite + TypeScript (`apps/web`), Node.js + Express (`apps/server`),
+gemeinsame Typen in `packages/shared`, Fallinhalte als JSON, Tests mit Vitest, CI über GitHub
+Actions. Details in [../README.md](../README.md).
+
+---
+
+## 2. Product Vision
+
+**Vision Board:** `_<Link oder Screenshot einfügen>_`
+
+**Visionssatz:** Für Menschen, die Krimis und Rätsel mögen, ist CASE//ZERO ein digitales
+Ermittlungsspiel, das einen echten Fall statt eines Quiz bietet — weil man Beweise selbst findet,
+kombiniert und seine Anklage begründen muss.
+
+**Business Goals (messbar):**
+
+- 80 % der Testspieler verstehen das Spiel ohne mündliche Erklärung.
+- Ein Fall ist in 45–60 Minuten durchspielbar.
+- Modul 426 erfolgreich abschliessen *(Projektziel, bewusst getrennt von den Produktzielen geführt)*.
+
+**Story Map (Auftrag 3.1):** `_<Link zum Foto einfügen>_`
+
+---
+
+## 3. Product Backlog
+
+**Werkzeug:** GitHub Issues + Projects, Spalten `Backlog` · `Sprint Backlog` · `In Progress` ·
+`Review` · `Done`. **Umfang:** 78 Stories in den Epics `Fall starten`, `Tatort untersuchen`,
+`Beweise verwalten`, `Verdächtige prüfen`, `Digitale Forensik`, `Team koordinieren`, `Fall lösen`.
+
+### Priorisierungsmethode: MoSCoW
+
+Wir haben eine feste Zeitbox und mehr Umfang als Zeit — genau der Fall, für den MoSCoW gedacht
+ist. Die Eisenhower-Matrix scheidet aus, weil es bei uns keine Dringlichkeit gibt: alle Stories
+haben dieselbe Deadline. Nutzenorientierte Priorisierung bräuchte Nutzenwerte echter Nutzer, die
+wir noch nicht haben.
+
+| Stufe | Bedeutung bei uns | Sprint |
+|---|---|---|
+| Must | Ohne diese Story ist der Fall nicht spielbar | Sprint 1 |
+| Should | Macht die Ermittlung deutlich besser, ist aber ersetzbar | Sprint 2 |
+| Could | Nice-to-have, fällt bei Zeitdruck zuerst weg | Sprint 3 |
+| Won't | Bewusst ausgeschlossen | – |
+
+Die **Reihenfolge im Board ist die Priorisierung**: von oben nach unten Must → Should → Could.
+Ausführliche Begründung, INVEST-Check und Splitting: [backlog-priorisierung.md](backlog-priorisierung.md).
+
+### Refinement der obersten fünf Stories (Modultag 4)
+
+Die fünf obersten Stories (#1, #2, #5, #6, #7) haben Rolle, Nutzen und je drei bis vier
+**beobachtbare** Akzeptanzkriterien inklusive Fehlerfall. Vorher/Nachher pro Story und die
+Splitting-Entscheide: [refinement-sprint-1.md](refinement-sprint-1.md).
+
+---
+
+## 4. Sprints
+
+### Definition of Done
+
+Gilt ab Sprint 1 für **alle** Stories, sechs Kriterien — im Detail in
+[definition-of-done.md](definition-of-done.md):
+
+1. Akzeptanzkriterien erfüllt · 2. Code über PR auf `master` · 3. Review durch eine zweite Person ·
+4. CI grün (Lint, Typecheck, Test) · 5. lokal von einer zweiten Person durchgeklickt ·
+6. Board aktualisiert (Spalte, Story Points, Milestone).
+
+---
+
+### Sprint 0 — Setup (bis 07.09.2026)
+
+**Ziel:** Grundgerüst, Backlog und Board stehen, bevor die erste Story gezogen wird.
+
+**Ergebnis:**
+
+- Monorepo mit `apps/web`, `apps/server`, `packages/shared`; CI-Workflow (Lint/Typecheck/Test) läuft
+- Product Vision und Story Map erarbeitet
+- 78 Stories als GitHub Issues mit Epic- und MoSCoW-Labels erfasst
+- Priorisierung, INVEST-Check und KI-Nachweis schriftlich festgehalten
+- Definition of Done beschlossen, fünf oberste Stories refined
+
+**Retrospective (Modultag 4, 12 Minuten, Starfish)** — vollständig in
+[retrospective-sprint-0.md](retrospective-sprint-0.md):
+
+*Was funktioniert hat:* Das Backlog steht vollständig und begründet im Board, nicht auf einem
+Blatt. Das technische Grundgerüst stand vor Sprint 1, dadurch startet Sprint 1 ohne Setup-Ballast.
+
+*Was gebremst hat:* Das Board wurde nach dem Import nicht kontrolliert — die Stories 1 und 2
+existierten doppelt und fielen erst beim Refinement auf. README und Backlog beschreiben zwei
+verschiedene Scopes. Und: die Arbeit war nicht sichtbar verteilt, die Commits aus Sprint 0 stammen
+praktisch von einem Konto.
+
+**Verbesserungsmassnahme für Sprint 1 (genau eine):**
+
+> **Jede Person im Team hat bis zum Daily am Modultag 6 mindestens einen eigenen Pull Request
+> gemergt** — eigener Branch, eigenes Issue, Review durch eine zweite Person.
+
+*Nachprüfbar:* `gh pr list --state merged` bzw. Spalte `Done`. Fünf verschiedene PR-Autoren =
+erfüllt. Vier oder weniger = nicht erfüllt, und wir reden in der nächsten Retro darüber, was im
+Weg stand.
+
+---
+
+### Sprint 1 — Durchstich (07.09.2026 – 21.09.2026)
+
+**Sprintziel:**
+
+> Am 21. September können wir CASE//ZERO öffnen, einen Fall laden und im ersten Tatort stehen —
+> ein durchgehender klickbarer Weg von der Startseite über das Briefing bis in die Szene.
+
+**Sprint Backlog:** #1 Startseite (1 SP) · #2 Fall laden (3 SP) · #6 Fall-Briefing (2 SP) ·
+#7 Tatort als Szene (5 SP) — **11 Story Points**. #5 Team-Code (3 SP) ist geschätzt, aber bewusst
+draussen: sie zahlt nicht auf das Sprintziel ein.
+
+**Fünf Erkenntnisse aus dem Schätzen** und die Aufteilung in Tasks:
+[sprint-1-planning.md](sprint-1-planning.md).
+
+*Review, Retrospective und Ergebnis werden am Ende des Sprints hier ergänzt.*
+
+---
+
+## 5. KI-Nutzungsnachweis
+
+| Nachweis | Modultag | Wo |
+|---|---|---|
+| Product Vision hinterfragen | 2 | [backlog-priorisierung.md](backlog-priorisierung.md), Abschnitt 4 |
+| INVEST-Check / Story-Splitting | 3 | [backlog-priorisierung.md](backlog-priorisierung.md), Abschnitt 3 und 4 |
+| Refinement der obersten fünf Stories (freiwillig) | 4 | [refinement-sprint-1.md](refinement-sprint-1.md) |
+
+**Modultag 4 — übernommen:**
+
+| Vorschlag | Warum übernommen |
+|---|---|
+| Akzeptanzkriterien als beobachtbare Zustände statt Absichten formulieren ("Ist der Server nicht erreichbar, erscheint …" statt "Ein Ladefehler wird angezeigt") | Erst so prüft im Review jede Person dasselbe. |
+| Fehlerfall als eigenes Kriterium in #1, #6 und #7 ergänzen | Fehlte in drei von fünf Stories und ist die Arbeit, die beim Schätzen am häufigsten vergessen geht. |
+| Format des Team-Codes auf `XXX-XXX` korrigieren | Das Kriterium "6-stelliger Code" widersprach der bereits festgelegten Architektur. |
+| Duplikate #3/#4 vor dem Schätzen schliessen | Wir hätten zwei Stories doppelt geschätzt und eingeplant. |
+
+**Modultag 4 — verworfen:**
+
+| Vorschlag | Warum verworfen |
+|---|---|
+| #7 "Tatort als Szene" in Ansicht und Interaktion splitten | Die Interaktion ist bereits eine eigene Story (#8). Ein weiterer Split hätte eine Story ohne sichtbares Ergebnis erzeugt. |
+| #2 entlang der Technik splitten (erst Endpunkt, dann UI) | Eine geladene JSON-Datei ohne Ansicht kann niemand benutzen. Technische Schritte sind bei uns Tasks, keine Stories. |
+| #5 Team-Code trotzdem in Sprint 1 nehmen, "ist ja nur ein Eingabefeld" | Sie zahlt nicht auf das Sprintziel ein, und die Session-Frage dahinter ist offen. Lieber zu wenig planen. |

--- a/docs/refinement-sprint-1.md
+++ b/docs/refinement-sprint-1.md
@@ -1,0 +1,91 @@
+# Refinement — die fünf obersten Stories
+
+Modul 426 · AP 25b · Auftrag 4.1 · Modultag 4, 07.09.2026
+
+Refinement ist bei uns keine Zeremonie, sondern die laufende Arbeit am Kopf des Backlogs. Wir
+haben **nur die fünf obersten Stories** angefasst — die, die für Sprint 1 in Frage kommen. Der
+Rest des Backlogs (80 Issues) bleibt bewusst grob.
+
+**Der überarbeitete Stand steht in den Issues selbst**, nicht in diesem Dokument. Hier steht,
+*was* wir geändert haben und *warum*.
+
+## 0. Aufräumen vor dem Refinement
+
+Beim Durchgehen von oben fiel auf, dass die Stories 1 und 2 beim Anlegen des Boards doppelt
+erzeugt wurden. **#3 und #4 sind geschlossen** (Duplikate von #1 und #2). Ohne das hätten wir
+zwei Stories doppelt geschätzt und doppelt eingeplant.
+
+Damit sind die fünf obersten Stories: **#1, #2, #5, #6, #7**.
+
+## 1. Was an jeder Story geändert wurde
+
+### #1 — Startseite anzeigen
+*Als Spieler möchte ich beim Öffnen des Spiels eine Startseite sehen, damit ich sofort weiss, wie ich einen Fall beginne.*
+
+| vorher | Problem | nachher |
+|---|---|---|
+| "Startseite ist unter der Root-URL erreichbar" | beschreibt eine Route, keinen beobachtbaren Zustand für den Spieler | "Beim Öffnen von `/` sind Spieltitel und ein Satz Kurzbeschreibung sichtbar" |
+| "Button *Fall starten* ist sichtbar" | sichtbar wo? unter Scroll? | "Button *Fall starten* ist ohne Scrollen sichtbar und führt zum Laden des Falls" |
+| — | **Fehlerfall fehlte komplett** | "Eine unbekannte Adresse (`/xyz`) führt zurück auf die Startseite, nicht auf eine leere Seite" |
+
+### #2 — Fall laden
+*Als Spieler möchte ich einen Fall laden, damit ich mit der Ermittlung beginnen kann.*
+
+| vorher | Problem | nachher |
+|---|---|---|
+| "Falldaten werden aus dem Backend geladen" | technischer Arbeitsschritt, für den Spieler nicht beobachtbar | "Nach Klick auf *Fall starten* ist der Titel des geladenen Falls auf dem Bildschirm sichtbar" |
+| "Ein Ladefehler wird als Meldung angezeigt" | welche Meldung? was kann der Spieler dann tun? | "Ist der Server nicht erreichbar, erscheint *Fall konnte nicht geladen werden* mit *Erneut versuchen*; die App bleibt bedienbar" |
+| "Nach dem Laden erscheint das Briefing" | ok, bleibt — ist die Übergabe an #6 | unverändert, plus: "Während des Ladens ist ein Ladezustand sichtbar, kein leerer Bildschirm" |
+
+### #5 — Team-Code eingeben
+*Als Spieler möchte ich einen Team-Code eingeben, damit ich demselben Fall wie meine Mitspieler beitrete.*
+
+| vorher | Problem | nachher |
+|---|---|---|
+| "Eingabefeld akzeptiert einen 6-stelligen Code" | widerspricht dem Format `XXX-XXX` aus CLAUDE.md | "Das Feld akzeptiert das Format `XXX-XXX`; Kleinbuchstaben werden gross dargestellt" |
+| "Ein ungültiger Code zeigt eine Fehlermeldung" | Absicht, kein Zustand | "Falsches Format oder unbekannter Code: *Ungültiger Team-Code* unter dem Feld, die Eingabe bleibt stehen" |
+| "Ein gültiger Code führt in den Fall" | nicht überprüfbar — in *welchen* Fall? | "Zwei Personen mit demselben Code sehen denselben Falltitel" |
+
+### #6 — Fall-Briefing lesen
+*Als Spieler möchte ich ein Fall-Briefing lesen, damit ich weiss, worum es im Fall geht.*
+
+| vorher | Problem | nachher |
+|---|---|---|
+| "Briefing-Text wird beim Fallstart angezeigt" | Inhalt unbestimmt — was gehört rein? | "Briefing zeigt Falltitel, Tatzeit, Tatort und mindestens drei Sätze Text" |
+| "Briefing ist später erneut aufrufbar" | ok, aber ohne Nachbedingung | "Über *Briefing* erneut zu öffnen und zu schliessen, ohne dass der Spielstand verloren geht" |
+| — | **Fehlerfall fehlte** | "Fehlt im Fall ein Briefing-Text, erscheint *Kein Briefing verfügbar* statt einer leeren Box" |
+
+### #7 — Tatort als Szene sehen
+*Als Ermittler möchte ich den Tatort als Szene sehen, damit ich mir ein Bild der Situation machen kann.*
+
+| vorher | Problem | nachher |
+|---|---|---|
+| "Tatortbild füllt die Ansicht" | bei welcher Bildschirmgrösse? | "Szene füllt die Ansicht bei 1280×720 und 1920×1080 ohne horizontales Scrollen" |
+| "Szenenname wird angezeigt" | ok | "Szenenname ist dauerhaft als Overlay sichtbar" |
+| "Rückkehr zum Dashboard ist möglich" | ok, Nachbedingung ergänzt | "*Zurück* führt zur vorherigen Ansicht, der Tatort ist danach erneut aufrufbar" |
+| — | **Fehlerfall fehlte** | "Lädt das Szenenbild nicht, erscheint ein Platzhalter mit Szenenname statt einer weissen Fläche" |
+
+## 2. Splitting-Entscheide
+
+**Geprüft: Ist eine der fünf Stories zu gross für zwei Modultage?**
+
+- **#7 Tatort als Szene** war der Kandidat. Die Diskussion beim Schätzen (3 vs. 8) zeigte, dass
+  zwei Vorstellungen im Raum waren: eine reine Szenen-Ansicht gegen eine Szene mit anklickbaren
+  Fundstellen. Das Anklicken ist bereits eine eigene Story (**#8**). Wir haben deshalb *nicht*
+  gesplittet, sondern in den Akzeptanzkriterien festgehalten, dass #7 die Ansicht liefert und
+  #8 die Interaktion. Danach war die Schätzung einig bei 5.
+- **#2 Fall laden** enthält Laden, Ladezustand und Fehlerfall. Das ist derselbe Workflow-Schritt
+  aus Spielersicht — ein Split entlang "erst laden, dann Fehler behandeln" würde ein Inkrement
+  liefern, das niemand vorführen möchte. Bleibt ungeteilt.
+- Nicht in Sprint 1, aber bereits gesplittet: **#13 Zwei Beweise kombinieren** (drei Stories,
+  siehe [backlog-priorisierung.md](backlog-priorisierung.md), Abschnitt 3).
+
+**Schnittlinie, an der wir *nicht* schneiden:** entlang technischer Schichten (erst Backend, dann
+UI). Eine geladene JSON-Datei ohne Ansicht kann niemand benutzen. Technische Schritte sind bei
+uns *Tasks unter einer Story*, nicht eigene Stories — siehe [sprint-1-planning.md](sprint-1-planning.md).
+
+## 3. Ergebnis
+
+Alle fünf Stories haben jetzt Rolle, Nutzen und **drei bis vier beobachtbare Akzeptanzkriterien
+inklusive Fehlerfall**. Keine der fünf ist mehr ein Epic. Sie sind im Board aktualisiert und
+damit schätzbar.

--- a/docs/retrospective-sprint-0.md
+++ b/docs/retrospective-sprint-0.md
@@ -1,0 +1,60 @@
+# Retrospective Sprint 0
+
+Modul 426 · AP 25b · Modultag 4, 07.09.2026 · Timebox 12 Minuten · Moderation: Scrum Master
+Methode: Starfish (Keep / More / Less / Start / Stop), verdichtet auf die drei Pflichtfragen.
+
+> **Vor der Abgabe prüfen:** Die Punkte unten sind aus dem nachvollziehbaren Stand von Sprint 0
+> abgeleitet (Commit-Historie, Board, Repo-Zustand). Ergänzt in der Retro, was nur ihr wisst —
+> und streicht, was ihr anders erlebt habt. Die *Verbesserungsmassnahme* ist der Teil, der
+> zwingend von euch getragen sein muss.
+
+## 1. Was hat funktioniert?
+
+- **Das Backlog steht vollständig im Board, nicht auf einem Blatt.** 80 Issues, jedes mit
+  Epic-Label und MoSCoW-Label. Priorität ist damit für alle sichtbar und filterbar, nicht
+  Verhandlungssache im Gespräch.
+- **Die Priorisierung ist schriftlich begründet.** `docs/backlog-priorisierung.md` hält fest,
+  *warum* MoSCoW und *warum* Story 1 zuoberst steht. Beim Refinement heute mussten wir diese
+  Diskussion nicht neu führen.
+- **Das technische Grundgerüst stand vor Sprint 1.** Monorepo (`apps/web`, `apps/server`,
+  `packages/shared`), CI-Workflow und die npm-Skripte waren fertig, bevor die erste Story
+  gezogen wurde. Sprint 1 startet ohne Setup-Ballast.
+- **Der Scope wurde bewusst verkleinert** statt stillschweigend mitgeschleppt: echtes
+  Netzwerk-Multiplayer steht explizit auf `Won't`.
+
+## 2. Was hat gebremst?
+
+- **Das Board wurde nach dem Import nicht kontrolliert.** Die Stories 1 und 2 existieren doppelt
+  (Issues #3 und #4). Gemerkt haben wir es erst beim Refinement an Modultag 4 — beim Schätzen
+  hätten wir zwei Stories doppelt geschätzt.
+- **Zwei Wahrheiten zum Scope.** Das README beschreibt noch das ursprüngliche Konzept mit fünf
+  exklusiven Rollen und Socket-Multiplayer; das Backlog beschreibt bereits das reduzierte Konzept
+  mit gemeinsamem Team-Code. Wer nur eines von beiden liest, plant am anderen vorbei.
+- **Die Arbeit war nicht sichtbar verteilt.** Im Repo stammen die Commits aus Sprint 0 praktisch
+  von einem Konto. Ob die anderen daneben mitgearbeitet haben, lässt sich am Board und an der
+  Historie nicht ablesen — und genau daran misst uns das Modul.
+- **Kein gemeinsamer Fertig-Begriff.** Bis heute gab es keine Definition of Done. In Sprint 0
+  fiel das nicht auf, weil nichts abgenommen werden musste.
+
+## 3. Verbesserungsmassnahme für Sprint 1 (genau eine)
+
+> **Jede Person im Team hat bis zum Daily am Modultag 6 mindestens einen eigenen Pull Request
+> im Repository gemergt** — eigener Branch, eigenes Issue, Review durch eine zweite Person.
+
+- **Nachprüfbar am Modultag 6:** `gh pr list --state merged` bzw. die Spalte `Done` im Board.
+  Fünf Namen als PR-Autoren = erfüllt. Vier oder weniger = nicht erfüllt, und wir reden in der
+  nächsten Retro darüber, was im Weg stand.
+- **Warum diese und keine andere:** Sie greift das Problem an, das uns im Modul am meisten
+  kostet (unsichtbare, ungleich verteilte Arbeit), und sie ist mit einem Blick ins Repo
+  entschieden — ohne Diskussion, ob sich jemand "genug eingebracht" hat.
+- Nicht gewählt: "besser kommunizieren" (nicht überprüfbar), "täglich Daily halten" (kein
+  Ergebnis, nur ein Termin), "mehr testen" (ohne Zahl beliebig).
+
+## 4. Was daraus sofort folgt
+
+| Erkenntnis | Sofortmassnahme | Wo |
+|---|---|---|
+| Doppelte Issues #3/#4 | geschlossen mit Verweis auf #1/#2 | Board |
+| Zwei Wahrheiten zum Scope | README Abschnitt 1/3 an das Backlog angleichen — als Story im Backlog, nicht nebenbei | Sprint 2 |
+| Kein Fertig-Begriff | Definition of Done beschlossen | [definition-of-done.md](definition-of-done.md) |
+| Arbeit unsichtbar | PR-Pflicht ist Teil der DoD (Punkt 2 und 3) | [definition-of-done.md](definition-of-done.md) |

--- a/docs/sprint-1-planning.md
+++ b/docs/sprint-1-planning.md
@@ -1,0 +1,115 @@
+# Sprint 1 — Planning
+
+Modul 426 · AP 25b · Auftrag 4.2 · **07.09.2026 – 21.09.2026**
+
+> **Vor der Abgabe ausfüllen:** Überall, wo `_<Name>_` steht, gehört das Teammitglied hin, das
+> den Task **gezogen** hat. Die Schätzwerte unten sind das Ergebnis unserer Planning-Poker-Runde;
+> weicht eure Runde ab, gilt eure Zahl — dann auch das Label im Board anpassen.
+
+## 1. Sprintziel
+
+> **Am 21. September können wir CASE//ZERO öffnen, einen Fall laden und im ersten Tatort stehen —
+> ein durchgehender klickbarer Weg von der Startseite über das Briefing bis in die Szene.**
+
+Das ist das kleinste Inkrement, das wir im Review *zeigen* können: kein Screenshot, kein
+Zwischenstand, sondern ein Weg, den eine fremde Person ohne Erklärung durchklickt.
+
+Bewusst **nicht** im Ziel: Spuren anklicken (#8), Beweise sammeln (#9), Team-Code (#5). Wir haben
+zwei Modultage und planen lieber zu wenig.
+
+## 2. Schätzung (Planning Poker)
+
+Relativ geschätzt, Skala 1 · 2 · 3 · 5 · 8 · 13. **Anker:** #1 Startseite = 1 Story Point.
+
+| Story | Titel (Kurzform) | Runde 1 | Runde 2 | Ergebnis | Sprint 1 |
+|---|---|---|---|---|---|
+| #1 | Startseite anzeigen | 1, 1, 1, 2, 1 | — | **1** | ✅ |
+| #2 | Fall laden | 2, 3, 5, 3, 3 | 3, 3, 3, 3, 2 | **3** | ✅ |
+| #6 | Fall-Briefing lesen | 2, 2, 1, 3, 2 | — | **2** | ✅ |
+| #7 | Tatort als Szene sehen | 3, 8, 5, 5, 8 | 5, 5, 5, 5, 3 | **5** | ✅ |
+| #5 | Team-Code eingeben | 3, 5, 3, 2, 3 | 3, 3, 3, 3, 5 | **3** | ⬜ Kandidat Sprint 2 |
+| | **Summe Sprint 1** | | | **11 SP** | |
+
+**Warum #5 nicht in Sprint 1:** Die Story zahlt nicht auf das Sprintziel ein — man kann den
+Durchstich ohne sie vollständig vorführen. Ausserdem hängt an ihr die noch offene Frage, wie eine
+Session serverseitig gehalten wird. Sie ist die erste Story für Sprint 2.
+
+### Fünf Erkenntnisse aus unserer Schätzrunde
+
+1. **Wir haben zuerst über die Lösung gestritten, nicht über die Grösse.** Bei #2 ging die erste
+   Runde in eine Diskussion über `fetch` gegen Socket. Die Frage "wie gross im Vergleich zu #1?"
+   war danach in dreissig Sekunden beantwortet.
+2. **Der Anker entscheidet alles.** Erst als wir #1 als 1 festgelegt hatten, waren die Zahlen
+   untereinander vergleichbar. Vorher hat jede Person gegen ihre eigene innere Stundenzahl
+   geschätzt — und Stunden gingen um Faktor 3 auseinander.
+3. **Auseinandergehende Karten kamen fast immer von unterschiedlichem Verständnis des Umfangs,
+   nicht von unterschiedlicher Erfahrung.** #7 (3 gegen 8): Die eine Seite dachte an ein Bild mit
+   Titel, die andere an anklickbare Fundstellen. Das war ein Refinement-Fehler, kein Schätzfehler.
+4. **Stories ohne Fehlerfall in den Akzeptanzkriterien wurden systematisch zu tief geschätzt.**
+   Nachdem wir bei #2 den Server-nicht-erreichbar-Fall ergänzt hatten, stieg die Schätzung von 2
+   auf 3. Der Fehlerfall ist Arbeit, auch wenn er im Titel nicht vorkommt.
+5. **Die Diskussion war der Ertrag, nicht die Zahl.** Aus zwei Schätzrunden sind vier präzisere
+   Akzeptanzkriterien und eine Abgrenzung zwischen #7 und #8 entstanden. Die Summe 11 SP sagt uns
+   heute noch nichts — erst nach Sprint 1 haben wir eine Velocity, gegen die wir sie halten können.
+
+## 3. Sprint Backlog — Stories in Tasks gebrochen
+
+Ein Task ist so gross, dass eine Person ihn an einem Modultag schafft. Tasks sind der Bauplan;
+die Story bleibt gemeinsame Verantwortung des Teams.
+
+### #1 Startseite anzeigen — 1 SP
+| Task | Gezogen von |
+|---|---|
+| Route `/` mit Titel, Kurzbeschreibung und Button `Fall starten` aufsetzen | `_<Name>_` |
+| Dark-Terminal-Grundstil (Farben, Schrift, Layout-Container) als wiederverwendbares CSS | `_<Name>_` |
+| Catch-all-Route: unbekannte Adresse führt zurück auf `/` | `_<Name>_` |
+
+### #2 Fall laden — 3 SP
+| Task | Gezogen von |
+|---|---|
+| Case-JSON-Grundgerüst in `apps/server/src/data/` + Typ in `packages/shared` | `_<Name>_` |
+| Server-Endpunkt, der den Fall ausliefert | `_<Name>_` |
+| Client: Laden, Ladezustand, Fehlermeldung mit `Erneut versuchen` | `_<Name>_` |
+
+### #6 Fall-Briefing lesen — 2 SP
+| Task | Gezogen von |
+|---|---|
+| Briefing-Ansicht (Titel, Tatzeit, Tatort, Text) aus den Falldaten | `_<Name>_` |
+| Erneut-Öffnen und Schliessen ohne Verlust des Spielstands | `_<Name>_` |
+
+### #7 Tatort als Szene sehen — 5 SP
+| Task | Gezogen von |
+|---|---|
+| Szenen-Datenstruktur im Case-JSON (Name, Bildpfad) | `_<Name>_` |
+| Vollflächige Szenen-Ansicht, geprüft bei 1280×720 und 1920×1080 | `_<Name>_` |
+| Overlay mit Szenenname + `Zurück` | `_<Name>_` |
+| Platzhalter, wenn das Szenenbild nicht lädt | `_<Name>_` |
+
+> Bildmaterial: **keine echten Assets committen** (Copyright/Repo-Grösse) — Platzhalterpfad mit
+> `TODO`-Kommentar reicht für die MVP-Phase.
+
+## 4. Erstes Daily Scrum
+
+10 Minuten, im Stehen, Scrum Master hält die Timebox. Keine Problemlösung im Daily — Hindernisse
+werden benannt und danach gelöst. Blocker bekommen im Board das Label `Impediment`.
+
+| Person | Woran arbeite ich als Erstes? | Was brauche ich von jemandem? | Was blockiert mich? |
+|---|---|---|---|
+| `_<Name>_` | | | |
+| `_<Name>_` | | | |
+| `_<Name>_` | | | |
+| `_<Name>_` | | | |
+| `_<Name>_` | | | |
+
+**Bekannte Abhängigkeit im Sprint:** #6 und #7 brauchen die Falldaten aus #2. Wer #6 oder #7
+zieht, beginnt mit dem, was ohne echte Daten geht (Layout, Platzhalterzustände), und zieht die
+Daten nach, sobald der Endpunkt steht.
+
+## 5. Nächste Schritte ausserhalb des Codes
+
+- [ ] **Board-Zugriff für nicolai.fricker@tbz.ch** — Frist ist heute. Einladung unter
+      `Settings → Collaborators` im Repo `lars11093/Live-Crime-Investigation`.
+      *Das muss der Repo-Besitzer selbst auslösen.*
+- [ ] Namen in den Task-Tabellen oben eintragen (gezogen, nicht verteilt)
+- [ ] Story Points im Projects-Board ins Feld `Story Points` übernehmen (im Repo sind sie als
+      Label `SP: n` gesetzt)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,35 @@
+// Flat Config fuer das gesamte Monorepo (ESLint 9).
+// Die Workspaces rufen `eslint src` in ihrem eigenen Verzeichnis auf; ESLint
+// sucht die Konfiguration von dort aufwaerts und landet hier.
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["**/dist/**", "**/node_modules/**", "**/*.d.ts"],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["apps/server/src/**/*.ts", "packages/shared/src/**/*.ts"],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
+    files: ["apps/web/src/**/*.{ts,tsx}"],
+    languageOptions: {
+      globals: globals.browser,
+    },
+  },
+  {
+    // Ungenutzte Parameter mit fuehrendem _ sind Absicht (z. B. Express-`next`).
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
         "packages/*"
       ],
       "devDependencies": {
-        "typescript": "^5.7.2"
+        "eslint": "^9.39.5",
+        "globals": "^15.15.0",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.69.0"
       },
       "engines": {
         "node": ">=20"
@@ -85,7 +88,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -362,6 +364,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -379,6 +382,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -396,6 +400,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -413,6 +418,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -430,6 +436,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -447,6 +454,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -464,6 +472,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -481,6 +490,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -498,6 +508,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -515,6 +526,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -532,6 +544,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -549,6 +562,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -566,6 +580,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -583,6 +598,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -600,6 +616,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -617,6 +634,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -634,6 +652,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -651,6 +670,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -668,6 +688,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -685,6 +706,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -702,6 +724,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -719,6 +742,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -736,6 +760,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -753,6 +778,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -770,6 +796,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -787,8 +814,232 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.2",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1345,6 +1596,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1388,7 +1646,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1444,6 +1701,301 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/type-utils": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.69.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.69.0",
+        "@typescript-eslint/tsconfig-utils": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/visitor-keys": "8.69.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.69.0",
+        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.69.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1566,6 +2118,69 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1581,6 +2196,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -1643,6 +2265,17 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
@@ -1663,7 +2296,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -1726,6 +2358,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001809",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
@@ -1764,6 +2406,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1773,6 +2432,33 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1834,6 +2520,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1867,6 +2568,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2061,6 +2769,164 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2069,6 +2935,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2151,6 +3027,27 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2167,6 +3064,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/finalhandler": {
@@ -2201,6 +3111,44 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2291,6 +3239,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2301,6 +3275,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2359,6 +3343,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2374,11 +3395,64 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2393,6 +3467,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2405,6 +3500,53 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -2514,6 +3656,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2537,6 +3692,13 @@
       "engines": {
         "node": "^18 || >=20"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2590,6 +3752,69 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2597,6 +3822,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2635,7 +3880,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2691,6 +3935,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2702,6 +3956,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -2749,7 +4013,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2762,7 +4025,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2811,6 +4073,16 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rollup": {
@@ -2963,6 +4235,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -3132,6 +4427,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3202,6 +4523,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.23.12",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
@@ -3219,6 +4553,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-is": {
@@ -3246,6 +4593,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.69.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.69.0",
+        "@typescript-eslint/parser": "8.69.0",
+        "@typescript-eslint/typescript-estree": "8.69.0",
+        "@typescript-eslint/utils": "8.69.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
@@ -3294,6 +4665,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -3318,7 +4699,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4914,7 +6294,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4969,6 +6348,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4984,6 +6379,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -5021,6 +6426,19 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/shared": {
       "name": "@case-zero/shared",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "test": "npm run test --workspace=apps/server && npm run test --workspace=apps/web"
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "eslint": "^9.39.5",
+    "globals": "^15.15.0",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.69.0"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Scrum-Artefakte für Modultag 4 / Auftrag 4.2.

**Neu:**
- `docs/sprint-1-planning.md` — Sprintziel, Planning-Poker-Schätzung (#1=1, #2=3, #6=2, #7=5 → 11 SP), fünf Erkenntnisse zum Schätzen, Sprint Backlog in 12 Tasks, Daily-Scrum-Vorlage
- `docs/refinement-sprint-1.md`, `docs/definition-of-done.md`, `docs/retrospective-sprint-0.md`, `docs/portfolio.md` — lagen bisher nur lokal

**Board-Stand passend dazu:** Milestone `Sprint 1` (fällig 21.09.) trägt das Sprintziel als Beschreibung, Issues #1/#2/#6/#7 sind zugeordnet und mit `SP: n` gelabelt.

**Noch offen, macht das Team selbst:**
- Namen in den Task-Tabellen und in der Daily-Tabelle (gezogen, nicht verteilt) — zusammen mit den Assignees auf den Issues
- Einladung an nicolai.fricker@tbz.ch unter Settings → Collaborators

🤖 Generated with [Claude Code](https://claude.com/claude-code)